### PR TITLE
update summary workflow dispatch check and add fail fast false

### DIFF
--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check workflow dispatch
         id: dispatch
-        if: ${{ inputs.build_only == '' }}
+        if: ${{ inputs.tot_hash == '' }} # tot_hash always set at apply tip of tree step in run_checks.yaml
         run: |
           echo "workflow_dispatch=true" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -165,6 +165,7 @@ jobs:
   patch_matrix:
     needs: [fetch_patches, prepare_sources]
     strategy:
+      fail-fast: false
       matrix:
         patch_name: ${{ fromJSON(needs.fetch_patches.outputs.list_of_patch_names) }}
     uses: ./.github/workflows/run_checks.yaml


### PR DESCRIPTION
`fail-fast: false` added because if one patch fails when multiple are tested at the same time, all others get cancelled ([run](https://github.com/ewlu/riscv-gnu-toolchain/actions/runs/6344215479))