### PR TITLE
Update start and older timestamp

### DIFF
--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -28,8 +28,8 @@ jobs:
           TZ=UTC date -d "@$((($(date +%s) + 0) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_recent.txt
           python scripts/get_previous_timestamp.py -token ${{ secrets.GITHUB_TOKEN }} -rid ${{ github.run_id }}
           START_TIME=$(cat date_cur.txt)
-          TZ=UTC date -d "@$((($(date -d $START_TIME +%s) + 0) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_old.txt
-          TZ=UTC date -d "@$((($(date -d $START_TIME +%s) - 900) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_older.txt
+          TZ=UTC date -d "@$((($(date -d $START_TIME +%s) - 900) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_old.txt
+          TZ=UTC date -d "@$((($(date -d $START_TIME +%s) - 1800) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_older.txt
 
           echo $START_TIME
           cat date_older.txt
@@ -44,9 +44,9 @@ jobs:
       - name: Update times for workflow dispatch
         if: ${{ inputs.timestamp != '' }}
         run: |
-          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) + 450) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_recent.txt
-          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) - 450) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_old.txt
-          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) - 1350) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_older.txt
+          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) + 0) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_recent.txt
+          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) - 900) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_old.txt
+          TZ=UTC date -d "@$((($(date -d '${{ inputs.timestamp }}' +%s) - 1800) / 900 * 900))" '+%Y-%m-%dT%H:%M:%S' > date_older.txt
 
       - name: Get list of new patches
         run: |


### PR DESCRIPTION
many scheduled runs have have start and end time being the exact same timestamp ([example](https://github.com/ewlu/riscv-gnu-toolchain/actions/runs/6391264650/job/17346159352#step:3:109))