### PR TITLE
Update march-to-cpu-opt

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -21,6 +21,8 @@ EXT_OPTS = {
   "zfinx":           "zfinx=true",
   "zdinx":           "zdinx=true",
   "zicond":          "x-zicond=true",
+  "zvfbfmin":        "zvfbfmin=true",
+  "zvfbfwma":        "zvfbfwma=true",
 }
 
 SUPPORTTED_EXTS = "iemafdcbvph"


### PR DESCRIPTION
In order to run vector bfloat16 test case, the vector bfloat16 flag in qemu should be added.